### PR TITLE
fix last element table width

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -611,7 +611,7 @@ tbody > tr > .table-header-identifier {
 }
 
 #lesson-outline-container {
-	th:last-of-type; {
+	th:last-of-type {
 		min-width: 120px;
 	}
 }


### PR DESCRIPTION
Fixed the last table column to 120px

## Before
<img width="970" alt="before" src="https://user-images.githubusercontent.com/9936028/73460585-a745f780-4370-11ea-8a67-f5902703039a.png">

## After
<img width="1002" alt="Screenshot 2020-01-30 at 14 54 47" src="https://user-images.githubusercontent.com/9936028/73460619-b62caa00-4370-11ea-8657-57df6458ed8f.png">
